### PR TITLE
Adds route for changing user password, and associated tests.

### DIFF
--- a/app/api/password.js
+++ b/app/api/password.js
@@ -1,0 +1,101 @@
+// password.js
+
+jwt = require('jsonwebtoken');
+bcrypt = require('bcrypt');
+
+module.exports = function(app, models) {
+
+  //change the user's password
+  app.post('/api/changepassword', function(req, res, next) {
+
+    var token = req.headers['x-access-token'];
+
+    if (req.body.OldPass == undefined || req.body.NewPass == undefined) {
+      console.log('password.js - Missing form data.');
+      res.status(400).json({
+        success: false,
+        message: 'Missing form data.'
+      });
+    } else {
+
+      if (token) {
+        jwt.verify(token, app.get('secret'), function(err, decoded) {
+          if (err) {
+            console.log('topic.js - failed to authenticate token.');
+            res.status(403).json({
+              success: false,
+              message: 'Failed to authenticate token.'
+            });
+          } else {
+
+            models.Profile.find({
+              where: {
+                Email: decoded.Email,
+                Archived: false
+              }}).then(function(profile) {
+                //verify old password
+                if (!bcrypt.compareSync(req.body.OldPass, profile.dataValues.Password)) {
+                  res.status(403).json({
+                    success: false,
+                    message: 'Bad password.'
+                  });
+                } else {
+
+                  //change to new password
+                  bcrypt.hash(req.body.NewPass, 10, function(err, hash) {
+
+                    models.Profile.update({
+                        Password: hash
+                      }, {
+                        where: {
+                          ProfileID: decoded.ProfileID
+                        }
+                      })
+                      .then(function(password) {
+                        res.json({
+                          success: true,
+                          message: 'Password changed.'
+                        });
+                      })
+                      .catch(function(err) {
+                        res.status(500).json({
+                          success: false,
+                          message: 'Encountered error: ' + err.message
+                        });
+                      });
+                  });
+                }
+              }); 
+          }
+        });
+      } else {
+        console.log('topic.js - No token provided.');
+        res.status(403).json({
+          success: false,
+          message: "No token provided."
+        });
+      }      
+    }
+  });
+
+  app.get('/api/changepassword', function(req, res) {
+    res.status(404).json({
+      success: false,
+      message: 'Method not allowed.'
+    });
+  }); 
+
+  app.put('/api/changepassword', function(req, res) {
+    res.status(404).json({
+      success: false,
+      message: 'Method not allowed.'
+    });
+  }); 
+
+  app.delete('/api/changepassword', function(req, res) {
+    res.status(404).json({
+      success: false,
+      message: 'Method not allowed.'
+    });
+  }); 
+};

--- a/app/routes.js
+++ b/app/routes.js
@@ -24,6 +24,7 @@ module.exports = function(app, passport) {
   var topic = require('./api/topic')(app, models);
   var comment = require('./api/comment')(app, models);
   var posting = require('./api/posting')(app, models);
+  var changepassword = require('./api/password')(app, models);
 
   //social routes
   var twitter = require('./api/twitter')(app, passport);

--- a/test/password.js
+++ b/test/password.js
@@ -1,0 +1,113 @@
+// /test/password.js
+
+module.exports = function(chai, server, assert, email, password) {
+
+  describe('/POST to /api/changepassword without token.', function() {
+    it('Should return JSON indicating failure.', function(done) {
+
+      chai.request(server)
+        .post('/api/changepassword')
+        .send({
+          OldPass: password,
+          NewPass: 'newpassword'
+        })
+        .end(function(err, res) {
+          assert.typeOf(res.body, 'object', 'Should return JSON object body.');
+          assert.equal(res.status, 403, 'Should return HTTP status of 403.');
+          assert.equal(res.body.success, false, 'Should indicate failure.');
+          done();
+        });
+    });
+  });
+
+  describe('/POST request to /api/changepassword with token but incorrect original password.', function() {
+    it('Should return JSON indicating failure.', function(done) {
+
+      chai.request(server)
+        .post('/api/login')
+        .send({
+          Email: email,
+          Password: password
+        })
+        .end(function(err, res) {
+
+          userToken = res.body.token;
+
+          chai.request(server)
+            .post('/api/changepassword')
+            .set('x-access-token', userToken)
+            .send({
+              OldPass: 'wrongpassword',
+              NewPass: 'newpassword'
+            })
+            .end(function(err, res) {
+              assert.typeOf(res.body, 'object', 'Should return JSON object body.');
+              assert.equal(res.status, 403, 'Should return HTTP status of 403.');
+              assert.equal(res.body.success, false, 'Should indicate failure.');
+              done();
+            });
+        });
+    });
+  });
+
+  describe('/POST request to /api/changepassword with token and correct credentials.', function() {
+    it('Should return JSON indicating success.', function(done) {
+
+      chai.request(server)
+        .post('/api/login')
+        .send({
+          Email: email,
+          Password: password
+        })
+        .end(function(err, res) {
+
+          userToken = res.body.token;
+
+          chai.request(server)
+            .post('/api/changepassword')
+            .set('x-access-token', userToken)
+            .send({
+              OldPass: password,
+              NewPass: 'newpassword'
+            })
+            .end(function(err, res) {
+              assert.typeOf(res.body, 'object', 'Should return JSON object body.');
+              assert.equal(res.status, 200, 'Should return HTTP status of 403.');
+              assert.equal(res.body.success, true, 'Should indicate failure.');
+              done();
+            });
+        });
+    });
+  });
+
+  describe('/POST request to /api/changepassword to change password back to original.', function() {
+    it('Should return JSON indicating success.', function(done) {
+
+      chai.request(server)
+        .post('/api/login')
+        .send({
+          Email: email,
+          Password: 'newpassword'
+        })
+        .end(function(err, res) {
+
+          userToken = res.body.token;
+
+          chai.request(server)
+            .post('/api/changepassword')
+            .set('x-access-token', userToken)
+            .send({
+              OldPass: 'newpassword',
+              NewPass: password
+            })
+            .end(function(err, res) {
+              assert.typeOf(res.body, 'object', 'Should return JSON object body.');
+              assert.equal(res.status, 200, 'Should return HTTP status of 403.');
+              assert.equal(res.body.success, true, 'Should indicate failure.');
+              done();
+            });
+        });
+    });
+  });
+
+};

--- a/test/test.js
+++ b/test/test.js
@@ -24,3 +24,5 @@ require('./profile')(chai, server, assert, orgEmail, orgPass);
 require('./topic')(chai, server, assert, email, password);
 require('./comment')(chai, server, assert, email, password);
 require('./posting')(chai, server, assert, orgEmail, orgPass);
+require('./password')(chai, server, assert, email, password);
+require('./password')(chai, server, assert, orgEmail, orgPass);


### PR DESCRIPTION
Make a POST request to /api/changepassword with a token and parameters OldPass and NewPass to change the password. Works for Users and Organizations.
